### PR TITLE
OI26 : Fixed Path Errors in Test Files

### DIFF
--- a/code/gits_add.py
+++ b/code/gits_add.py
@@ -1,7 +1,9 @@
 #!/usr/bin/python3
 
-import gits_logging
+
 from subprocess import Popen, PIPE
+
+from code import gits_logging
 
 
 def gits_add_func(args):

--- a/code/gits_all_branch.py
+++ b/code/gits_all_branch.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-import gits_logging
+
 from subprocess import Popen, PIPE
 
 def gits_all_branch_func(args):

--- a/test/test_checkout.py
+++ b/test/test_checkout.py
@@ -2,11 +2,11 @@ import argparse
 import os
 import sys
 
+
 sys.path.insert(1, os.getcwd())
 
-from gits_checkout import checkout
+from code.gits_checkout import checkout
 from mock import patch, Mock
-
 
 def parse_args(args):
     parser = argparse.ArgumentParser()

--- a/test/test_gits_add.py
+++ b/test/test_gits_add.py
@@ -1,9 +1,10 @@
 import os
 import sys
+
 sys.path.insert(1, os.getcwd())
 
 import argparse
-import gits_add
+from code import gits_add
 from mock import patch
 
 

--- a/test/test_gits_all_branch.py
+++ b/test/test_gits_all_branch.py
@@ -1,9 +1,12 @@
 import os
 import sys
+
+
+
 sys.path.insert(1, os.getcwd())
 
 import argparse
-import gits_all_branch
+from code import gits_all_branch
 from mock import patch, Mock
 
 def parse_args(args):

--- a/test/test_gits_commit.py
+++ b/test/test_gits_commit.py
@@ -1,9 +1,12 @@
 import argparse
 import os
 import sys
+
+
+
 sys.path.insert(1, os.getcwd())
 
-import gits_commit
+from code import gits_commit
 from mock import patch, Mock
 
 def parse_args(args):

--- a/test/test_gits_create_branch.py
+++ b/test/test_gits_create_branch.py
@@ -3,7 +3,7 @@ import sys
 sys.path.insert(1, os.getcwd())
 
 import argparse
-import gits_create_branch
+from code import gits_create_branch
 from mock import patch, Mock
 
 


### PR DESCRIPTION
Fixed path errors for half of the files:
1.test_checkout.py
2.test_gits_add.py
3.test_gits_all_branch.py
4.test_gits_commit.py
5.test_gits_create_branch.py